### PR TITLE
fix(markex-string): Fix the case when string terminator exists at the…

### DIFF
--- a/markex-tests.el
+++ b/markex-tests.el
@@ -71,7 +71,8 @@ Check if point is not moved."
   (markex--test-match #'markex-string "  \"foo\\\"bar\" " 4 12 :start 5)
   (markex--test-match #'markex-string " \"foo\" " 3 6 :start 2)
   (markex--test-match #'markex-string " \"foo\" " 3 6 :start 6)
-  (markex--test-match #'markex-string "\" \"" 2 3 :start 2))
+  (markex--test-match #'markex-string "\" \"" 2 3 :start 2)
+  (markex--test-match #'markex-string "\"\\\"foo\\\"\"" 2 9 :start 3))
 
 (ert-deftest markex-string--test-unmatch ()
   (markex--test-unmatch #'markex-string "foo")

--- a/markex-tests.el
+++ b/markex-tests.el
@@ -79,7 +79,8 @@ Check if point is not moved."
   (markex--test-unmatch #'markex-string " \"foo\" " :start 1)
   (markex--test-unmatch #'markex-string " \"foo\" " :start 7)
   (markex--test-unmatch #'markex-string " \"\" " :start 2)
-  (markex--test-unmatch #'markex-string " \"\" " :start 3))
+  (markex--test-unmatch #'markex-string " \"\" " :start 3)
+  (markex--test-unmatch #'markex-string "\"" :start 1))
 
 (ert-deftest markex-pair--test-match ()
   (markex--test-match #'markex-pair " (Hello wolrd) " 2 15 :start 5)

--- a/markex.el
+++ b/markex.el
@@ -184,12 +184,11 @@
           beg
           (save-excursion
             (goto-char beg)
-            (while (and (< 0 (skip-syntax-forward "^\"|"))
+            (while (and (not (eobp))
                         (progn
                           (forward-char 1)
                           (ppss-string-terminator (syntax-ppss))))
-              ;; nop
-              )
+              (skip-syntax-forward "^\"|"))
             (if (eq (point) beg)
                 beg
               (1- (point))))))))))


### PR DESCRIPTION
… end